### PR TITLE
CMake: Move tests behind config option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 enable_testing()
 
 project(cppparser VERSION 1.0.0)
@@ -13,6 +13,8 @@ if(MSVC)
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd\"4996\"")
 	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd\"4996\"")
 endif()
+
+option(CPPPARSER_BUILD_TESTS "Build tests" OFF)
 
 add_subdirectory(cppast)
 add_subdirectory(cppparser)

--- a/cppast/CMakeLists.txt
+++ b/cppast/CMakeLists.txt
@@ -20,6 +20,8 @@ target_include_directories(cppast
 )
 set_target_properties(cppast PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 
-add_subdirectory(test)
+if (CPPPARSER_BUILD_TESTS)
+  add_subdirectory(test)
+endif()
 
 install(DIRECTORY "include/cppast" DESTINATION "include")

--- a/cppparser/CMakeLists.txt
+++ b/cppparser/CMakeLists.txt
@@ -3,14 +3,17 @@ if(MSVC)
 	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd\"4996\"")
 endif()
 
-add_subdirectory(test)
 add_subdirectory(third_party/btyacc_tp)
 
-add_definitions(-DBOOST_AUTO_LINK_NOMANGLE)
+if (CPPPARSER_BUILD_TESTS)
+	add_subdirectory(test)
 
-add_subdirectory(../../common/third_party/boost_tp/cmake  ${CMAKE_BINARY_DIR}/boost)
+	add_definitions(-DBOOST_AUTO_LINK_NOMANGLE)
 
-include_directories(../../common/third_party)
+	add_subdirectory(../../common/third_party/boost_tp/cmake  ${CMAKE_BINARY_DIR}/boost)
+
+	include_directories(../../common/third_party)
+endif()
 
 #############################################
 ## CppParser


### PR DESCRIPTION
This allows building the library without needing the test-only dependencies